### PR TITLE
Adding more interpolation options in case of tstep 1

### DIFF
--- a/R/convert_item.R
+++ b/R/convert_item.R
@@ -117,6 +117,24 @@ convert_item <- function(.data,
     tagg <- item_param[type == "tagg"][1, value]
   }
 
+  # Interpolation method - auto-detect based on typical timestep
+  interp_method <- "linear"
+  if (nrow(item_param[type == "interp_method"]) > 0) {
+    interp_method <- item_param[type == "interp_method"][1, value]
+  } else {
+    # Calculate typical timestep from time mapping
+    tm <- time_mappings[[time_id]]
+    if (!is.null(tm) && nrow(tm) > 1) {
+      # Ensure refyear is numeric before calculating diff
+      refyears <- as.numeric(as.character(unique(tm$refyear)))
+      typical_tstep <- median(diff(sort(refyears)))
+      if (typical_tstep <= 1) {
+        interp_method <- "spline_monoH.FC"  # yearly or sub-yearly
+      }
+    }
+  }
+  convopt[["interp_method"]] <- interp_method
+
   .conv <- convert_table(.data,
     time_mapping = time_mappings[[time_id]],
     time_aggregate = tagg,

--- a/R/convert_table.R
+++ b/R/convert_table.R
@@ -54,6 +54,7 @@ convert_table <- function(.x,
   if (do_time_period) {
     time_params <- dots[which(names(dots) %in% c(
       "do_interp",
+      "interp_method",
       "do_extrap",
       "do_past_extrap",
       "year_name",

--- a/R/convert_time_period.R
+++ b/R/convert_time_period.R
@@ -11,9 +11,9 @@
 #'
 #' The time mapping between year and time period should be provided as
 #' a data.table with columns "year" and "t", and refyear for interpolation and
-#' extrapolation. In case of missing periods, these can be linearly interpolated
-#' or constantly interpolated. If several years are mapped into the same period,
-#' values are averaged or the function \code{fun.aggregate} is used.
+#' extrapolation. In case of missing periods, these can be interpolated using
+#' linear, exponential, or spline methods. If several years are mapped into the
+#' same period, values are averaged or the function \code{fun.aggregate} is used.
 #'
 #' @family conversion functions
 #' @seealso \code{\link{convert_table}},
@@ -21,8 +21,13 @@
 #'
 #' @param .x a well-formatted data.table.
 #' @param time_mapping a time mapping data.table.
-#' @param do_interp logical indicating whether linear interpolation
+#' @param do_interp logical indicating whether interpolation
 #' should be done.
+#' @param interp_method character string specifying interpolation method:
+#' "linear" (default), "exponential", or "spline" with optional method suffix.
+#' For spline interpolation, you can specify the method: "spline" (uses "fmm"),
+#' "spline_fmm", "spline_natural", "spline_periodic", "spline_monoH.FC", or
+#' "spline_hyman".
 #' @param do_extrap logical indicating whether constant extrapolation
 #' should be done.
 #' @param do_past_extrap logical indicating whether constant extrapolation
@@ -35,7 +40,7 @@
 #' @param verbose logical indicating whether running in verbose mode.
 #'
 #' @return a converted data.table
-#' @importFrom stats approx
+#' @importFrom stats approx splinefun
 #' @export
 #' @examples
 #'
@@ -49,6 +54,7 @@
 convert_time_period <- function(.x,
                                 time_mapping,
                                 do_interp = FALSE,
+                                interp_method = "linear",
                                 do_extrap = FALSE,
                                 do_past_extrap = FALSE,
                                 year_name = "year",
@@ -61,6 +67,38 @@ convert_time_period <- function(.x,
   # Check input
   if (!time_aggregate %in% c("mean", "sum", "max")) {
     stop(paste0("time_aggregate function not implemented."))
+  }
+
+  # Parse and validate interpolation method
+  .base_method <- interp_method
+  .spline_method <- "fmm"  # default for spline
+
+  if (startsWith(interp_method, "spline")) {
+    .base_method <- "spline"
+    if (interp_method != "spline") {
+      # Extract method after underscore
+      .parts <- strsplit(interp_method, "_", fixed = TRUE)[[1]]
+      if (length(.parts) == 2 && .parts[1] == "spline") {
+        .spline_method <- .parts[2]
+        if (!.spline_method %in% c("fmm", "natural", "periodic", "monoH.FC", "hyman")) {
+          stop(paste0(
+            "Invalid spline method '", .spline_method, "'. ",
+            "Must be one of: fmm, natural, periodic, monoH.FC, hyman."
+          ))
+        }
+      } else {
+        stop(paste0(
+          "Invalid interp_method format. ",
+          "Use 'spline' or 'spline_<method>' where method is one of: ",
+          "fmm, natural, periodic, monoH.FC, hyman."
+        ))
+      }
+    }
+  } else if (!.base_method %in% c("linear", "exponential")) {
+    stop(paste0(
+      "interp_method must be 'linear', 'exponential', or 'spline' ",
+      "(optionally with method suffix like 'spline_natural')."
+    ))
   }
 
   # Guess time mapping if not directly provided
@@ -121,10 +159,38 @@ convert_time_period <- function(.x,
         if (nrow(sd) == 1) {
           v <- sd[[value_name]]
         } else {
+          # Linear interpolation with constant extrapolation (rule = 2)
           v <- approx(
             x = sd[[year_name]], y = sd[[value_name]],
             xout = missing_time$year, rule = 2
           )$y
+
+          # Override interior points with alternative interpolation method
+          if (.base_method != "linear") {
+            .interp_mask <- missing_time$year >= min(sd[[year_name]]) &
+              missing_time$year <= max(sd[[year_name]])
+            if (any(.interp_mask)) {
+              if (.base_method == "exponential") {
+                if (any(sd[[value_name]] <= 0)) {
+                  warning(
+                    "Exponential interpolation requires positive values. ",
+                    "Using linear."
+                  )
+                } else {
+                  v[.interp_mask] <- exp(approx(
+                    x = sd[[year_name]], y = log(sd[[value_name]]),
+                    xout = missing_time$year[.interp_mask], rule = 1
+                  )$y)
+                }
+              } else if (.base_method == "spline") {
+                .spline_fn <- splinefun(
+                  x = sd[[year_name]], y = sd[[value_name]],
+                  method = .spline_method
+                )
+                v[.interp_mask] <- .spline_fn(missing_time$year[.interp_mask])
+              }
+            }
+          }
         }
         return(list(
           year = missing_time$year,

--- a/tests/testthat/test-convert-time-period.R
+++ b/tests/testthat/test-convert-time-period.R
@@ -144,3 +144,197 @@ test_that("convert time interpolation and extrapolation", {
 
   expect_equal(res1, res2)
 })
+
+test_that("convert time with exponential interpolation", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  # Data with exponential growth: 100 -> 200 (doubles in 10 years)
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(100, 200))
+
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    interp_method = "exponential",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Exponential interpolation: geometric mean at midpoint
+  # sqrt(100 * 200) = 141.42...
+  res2 <- data.table::data.table(
+    t = as.character(2:4),
+    value = c(100, sqrt(100 * 200), 200)
+  )
+  data.table::setkey(res2, t)
+
+  expect_equal(res1, res2, tolerance = 1e-6)
+})
+
+test_that("convert time with spline interpolation", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(1, 2))
+
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    interp_method = "spline",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Spline with only 2 points should be equivalent to linear
+  res2 <- data.table::data.table(
+    t = as.character(2:4),
+    value = c(1, 1.5, 2)
+  )
+  data.table::setkey(res2, t)
+
+  expect_equal(res1, res2, tolerance = 1e-6)
+})
+
+test_that("exponential interpolation with negative values falls back to linear", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(-1, 2))
+
+  # Should produce a warning and fall back to linear
+  expect_warning(
+    res1 <- convert_time_period(dd, tm,
+      do_interp = TRUE,
+      interp_method = "exponential",
+      verbose = FALSE
+    ),
+    "Exponential interpolation requires positive values"
+  )
+
+  data.table::setkey(res1, t)
+
+  # Should use linear interpolation as fallback
+  res2 <- data.table::data.table(
+    t = as.character(2:4),
+    value = c(-1, 0.5, 2)
+  )
+  data.table::setkey(res2, t)
+
+  expect_equal(res1, res2)
+})
+
+test_that("interpolation methods preserve constant extrapolation", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(100, 200))
+
+  # Test with exponential interpolation and extrapolation
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    do_extrap = TRUE,
+    interp_method = "exponential",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Extrapolation should be constant (100 before, 200 after)
+  # even though interpolation is exponential
+  res2 <- data.table::data.table(
+    t = as.character(1:5),
+    value = c(100, 100, sqrt(100 * 200), 200, 200)
+  )
+  data.table::setkey(res2, t)
+
+  expect_equal(res1, res2, tolerance = 1e-6)
+})
+
+test_that("invalid interpolation method raises error", {
+  dd <- data.table::data.table(year = 2005:2050, value = 1:46)
+
+  expect_error(
+    convert_time_period(dd, "t30", interp_method = "invalid"),
+    "interp_method must be 'linear', 'exponential', or 'spline'"
+  )
+})
+
+test_that("spline interpolation with natural method", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(100, 200))
+
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    interp_method = "spline_natural",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Should complete without error and have 3 time periods
+  expect_equal(nrow(res1), 3)
+  expect_equal(res1$t, as.character(2:4))
+  expect_equal(res1$value[1], 100)
+  expect_equal(res1$value[3], 200)
+})
+
+test_that("spline interpolation with monoH.FC method preserves monotonicity", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  # Monotonically increasing data
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(100, 200))
+
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    interp_method = "spline_monoH.FC",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Check monotonicity: values should be increasing
+  expect_true(all(diff(res1$value) >= 0))
+  expect_equal(res1$value[1], 100)
+  expect_equal(res1$value[3], 200)
+})
+
+test_that("spline interpolation with hyman method", {
+  tm <- time_mappings[["t30"]]
+  tm <- tm[year %in% 2003:2027, .(year, t, refyear)]
+
+  dd <- data.table::data.table(year = c(2010, 2020), value = c(100, 200))
+
+  res1 <- convert_time_period(dd, tm,
+    do_interp = TRUE,
+    interp_method = "spline_hyman",
+    verbose = FALSE
+  )
+
+  data.table::setkey(res1, t)
+
+  # Hyman method should preserve monotonicity
+  expect_true(all(diff(res1$value) >= 0))
+  expect_equal(res1$value[1], 100)
+  expect_equal(res1$value[3], 200)
+})
+
+test_that("invalid spline method raises error", {
+  dd <- data.table::data.table(year = 2005:2050, value = 1:46)
+
+  expect_error(
+    convert_time_period(dd, "t30", interp_method = "spline_invalid"),
+    "Invalid spline method"
+  )
+})
+
+test_that("invalid spline format raises error", {
+  dd <- data.table::data.table(year = 2005:2050, value = 1:46)
+
+  expect_error(
+    convert_time_period(dd, "t30", interp_method = "spline_method_extra"),
+    "Invalid interp_method format"
+  )
+})


### PR DESCRIPTION
Code should preserve legacy use by keeping linear interpolation as default for tstep 5. For tstep 1 (autodetected), the default is after testing: spline monoH.FC
